### PR TITLE
chore: ajout docs_local/ au gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ certs/
 *.pem
 *.key
 *.crt
+docs_local/


### PR DESCRIPTION
Sauvegarde locale des anciennes docs de design supprimées lors du merge de la nouvelle structure MkDocs (branche doc_julian).

Fichiers concernés (non versionnés, usage interne) :
- PRIORITE_1_IMPLEMENTATION.md
- PRIORITE_2_GAMEPLAY.md
- PRIORITE_3_RTYPE_AUTHENTIQUE.md
- ENEMY_AI_IMPROVEMENTS.md