### PR TITLE
feat(discord): Bot Discord Leaderboard

### DIFF
--- a/discord-bot/leaderboard/.env.example
+++ b/discord-bot/leaderboard/.env.example
@@ -1,0 +1,15 @@
+# Discord Bot Configuration
+# Copy this file to .env and fill in the values
+
+# Discord
+DISCORD_TOKEN=your_bot_token_here
+DISCORD_GUILD_ID=your_guild_id_for_fast_sync
+STATS_CHANNEL_ID=channel_id_for_stats
+
+# MongoDB (same as R-Type server - localhost on VPS)
+MONGODB_URI=mongodb://localhost:27017
+MONGODB_DB=rtype
+
+# Optional
+LOG_LEVEL=INFO
+EMBED_COLOR=0x00FF00

--- a/discord-bot/leaderboard/bot.py
+++ b/discord-bot/leaderboard/bot.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+R-Type Discord Bot - Leaderboard Module
+Entry point for the bot.
+"""
+
+import asyncio
+import logging
+import sys
+
+import discord
+from discord.ext import commands
+
+from config import Config
+from database.mongodb import MongoDB
+from cogs import EXTENSIONS
+
+
+class RTypeBot(commands.Bot):
+    """R-Type Leaderboard Discord Bot."""
+
+    def __init__(self):
+        intents = discord.Intents.default()
+        super().__init__(
+            command_prefix="!",
+            intents=intents,
+            description="R-Type Leaderboard Bot",
+        )
+        self.db = None
+
+    async def setup_hook(self):
+        """Setup hook called before the bot starts."""
+        # Connect to MongoDB
+        self.db = await MongoDB.connect(Config.MONGODB_URI, Config.MONGODB_DB)
+
+        # Load all cogs
+        for extension in EXTENSIONS:
+            try:
+                await self.load_extension(extension)
+                logging.info(f"Loaded extension: {extension}")
+            except Exception as e:
+                logging.error(f"Failed to load extension {extension}: {e}")
+
+        # Sync slash commands
+        if Config.DISCORD_GUILD_ID:
+            # Fast sync to specific guild (for development)
+            guild = discord.Object(id=Config.DISCORD_GUILD_ID)
+            self.tree.copy_global_to(guild=guild)
+            await self.tree.sync(guild=guild)
+            logging.info(f"Synced commands to guild {Config.DISCORD_GUILD_ID}")
+        else:
+            # Global sync (takes up to 1 hour to propagate)
+            await self.tree.sync()
+            logging.info("Synced commands globally")
+
+    async def on_ready(self):
+        """Called when bot is ready."""
+        logging.info(f"Logged in as {self.user} (ID: {self.user.id})")
+        logging.info(f"Connected to {len(self.guilds)} guild(s)")
+
+        # Set activity
+        activity = discord.Activity(
+            type=discord.ActivityType.watching,
+            name="R-Type Leaderboard",
+        )
+        await self.change_presence(activity=activity)
+
+    async def on_command_error(self, ctx, error):
+        """Global error handler."""
+        if isinstance(error, commands.CommandNotFound):
+            return
+        logging.error(f"Command error: {error}")
+
+    async def close(self):
+        """Cleanup on shutdown."""
+        await MongoDB.close()
+        await super().close()
+
+
+def setup_logging():
+    """Configure logging."""
+    level = getattr(logging, Config.LOG_LEVEL.upper(), logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    # Reduce discord.py noise
+    logging.getLogger("discord").setLevel(logging.WARNING)
+    logging.getLogger("discord.http").setLevel(logging.WARNING)
+
+
+def main():
+    """Main entry point."""
+    # Validate config
+    try:
+        Config.validate()
+    except ValueError as e:
+        print(f"Configuration error: {e}")
+        print("Please check your .env file")
+        sys.exit(1)
+
+    setup_logging()
+
+    bot = RTypeBot()
+
+    try:
+        bot.run(Config.DISCORD_TOKEN, log_handler=None)
+    except discord.LoginFailure:
+        logging.error("Invalid Discord token")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        logging.info("Shutting down...")
+
+
+if __name__ == "__main__":
+    main()

--- a/discord-bot/leaderboard/cogs/__init__.py
+++ b/discord-bot/leaderboard/cogs/__init__.py
@@ -1,0 +1,11 @@
+"""Cogs module for R-Type Discord Bot."""
+
+EXTENSIONS = [
+    "cogs.leaderboard",
+    "cogs.stats",
+    "cogs.achievements",
+    "cogs.online",
+    "cogs.history",
+]
+
+__all__ = ["EXTENSIONS"]

--- a/discord-bot/leaderboard/cogs/achievements.py
+++ b/discord-bot/leaderboard/cogs/achievements.py
@@ -1,0 +1,53 @@
+"""
+Achievements cog - /achievements command.
+"""
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from database.player_stats_repo import PlayerStatsRepository
+from utils.embeds import create_achievements_embed
+
+
+class AchievementsCog(commands.Cog):
+    """Achievement commands."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    async def player_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for player names."""
+        if len(current) < 1:
+            return []
+        names = await PlayerStatsRepository.search_players(current, limit=25)
+        return [app_commands.Choice(name=n, value=n) for n in names]
+
+    @app_commands.command(
+        name="achievements", description="Affiche les succes d'un joueur"
+    )
+    @app_commands.describe(player="Nom du joueur")
+    @app_commands.autocomplete(player=player_autocomplete)
+    async def achievements(self, interaction: discord.Interaction, player: str):
+        """Display player achievements."""
+        await interaction.response.defer()
+
+        achievements = await PlayerStatsRepository.get_achievements(player)
+
+        # Check if player exists (all achievements are False means not found or new player)
+        stats = await PlayerStatsRepository.get_by_name(player)
+        if not stats:
+            await interaction.followup.send(
+                f"❌ Joueur **{player}** non trouve.", ephemeral=True
+            )
+            return
+
+        embed = create_achievements_embed(achievements, player)
+        await interaction.followup.send(embed=embed)
+
+
+async def setup(bot: commands.Bot):
+    """Setup function for the cog."""
+    await bot.add_cog(AchievementsCog(bot))

--- a/discord-bot/leaderboard/cogs/history.py
+++ b/discord-bot/leaderboard/cogs/history.py
@@ -1,0 +1,65 @@
+"""
+History cog - /history command.
+Shows recent game history for a player.
+"""
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from database.player_stats_repo import PlayerStatsRepository
+from utils.embeds import create_history_embed
+
+
+class HistoryCog(commands.Cog):
+    """Game history command."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    async def player_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for player names."""
+        if len(current) < 1:
+            return []
+        names = await PlayerStatsRepository.search_players(current, limit=25)
+        return [app_commands.Choice(name=n, value=n) for n in names]
+
+    @app_commands.command(
+        name="history", description="Affiche les dernieres parties d'un joueur"
+    )
+    @app_commands.describe(player="Nom du joueur", limit="Nombre de parties (max 10)")
+    @app_commands.autocomplete(player=player_autocomplete)
+    async def history(
+        self, interaction: discord.Interaction, player: str, limit: int = 5
+    ):
+        """Display player game history."""
+        await interaction.response.defer()
+
+        # Clamp limit
+        limit = max(1, min(limit, 10))
+
+        history = await PlayerStatsRepository.get_game_history(player, limit)
+
+        if not history:
+            # Check if player exists
+            stats = await PlayerStatsRepository.get_by_name(player)
+            if not stats:
+                await interaction.followup.send(
+                    f"❌ Joueur **{player}** non trouve.", ephemeral=True
+                )
+                return
+
+            await interaction.followup.send(
+                f"📜 Aucune partie enregistree pour **{player}**.", ephemeral=True
+            )
+            return
+
+        embed = create_history_embed(history, player)
+        await interaction.followup.send(embed=embed)
+
+
+async def setup(bot: commands.Bot):
+    """Setup function for the cog."""
+    await bot.add_cog(HistoryCog(bot))

--- a/discord-bot/leaderboard/cogs/leaderboard.py
+++ b/discord-bot/leaderboard/cogs/leaderboard.py
@@ -1,0 +1,156 @@
+"""
+Leaderboard cog - /leaderboard, /rank, /weapon commands.
+"""
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from database.leaderboard_repo import LeaderboardRepository
+from database.player_stats_repo import PlayerStatsRepository
+from utils.embeds import create_leaderboard_embed, create_rank_embed
+
+
+class LeaderboardCog(commands.Cog):
+    """Leaderboard commands."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    async def player_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for player names."""
+        if len(current) < 1:
+            return []
+        names = await PlayerStatsRepository.search_players(current, limit=25)
+        return [app_commands.Choice(name=n, value=n) for n in names]
+
+    @app_commands.command(
+        name="leaderboard", description="Affiche le classement des joueurs"
+    )
+    @app_commands.describe(
+        category="Type de classement", period="Periode du classement"
+    )
+    @app_commands.choices(
+        category=[
+            app_commands.Choice(name="Score", value="score"),
+            app_commands.Choice(name="Kills", value="kills"),
+            app_commands.Choice(name="Wave", value="wave"),
+            app_commands.Choice(name="K/D Ratio", value="kd"),
+            app_commands.Choice(name="Boss Kills", value="bosses"),
+            app_commands.Choice(name="Temps de jeu", value="playtime"),
+        ]
+    )
+    @app_commands.choices(
+        period=[
+            app_commands.Choice(name="All-Time", value="all"),
+            app_commands.Choice(name="Weekly", value="weekly"),
+            app_commands.Choice(name="Monthly", value="monthly"),
+        ]
+    )
+    async def leaderboard(
+        self,
+        interaction: discord.Interaction,
+        category: str = "score",
+        period: str = "all",
+    ):
+        """Display leaderboard."""
+        await interaction.response.defer()
+
+        if category == "score":
+            data = await LeaderboardRepository.get_top_scores(period, 10)
+        elif category == "kills":
+            data = await LeaderboardRepository.get_top_kills(10)
+        elif category == "wave":
+            data = await LeaderboardRepository.get_top_waves(10)
+        elif category == "kd":
+            data = await LeaderboardRepository.get_top_kd(10)
+        elif category == "bosses":
+            data = await LeaderboardRepository.get_top_bosses(10)
+        elif category == "playtime":
+            data = await LeaderboardRepository.get_top_playtime(10)
+        else:
+            data = []
+
+        embed = create_leaderboard_embed(data, category, period)
+        await interaction.followup.send(embed=embed)
+
+    @app_commands.command(
+        name="rank", description="Affiche ton rang dans le classement"
+    )
+    @app_commands.describe(player="Nom du joueur")
+    @app_commands.autocomplete(player=player_autocomplete)
+    async def rank(self, interaction: discord.Interaction, player: str):
+        """Display player rank."""
+        await interaction.response.defer()
+
+        all_time = await LeaderboardRepository.get_player_rank(player, "all")
+        weekly = await LeaderboardRepository.get_player_rank(player, "weekly")
+        monthly = await LeaderboardRepository.get_player_rank(player, "monthly")
+
+        if all_time is None and weekly is None and monthly is None:
+            await interaction.followup.send(
+                f"❌ Joueur **{player}** non trouve.", ephemeral=True
+            )
+            return
+
+        embed = create_rank_embed(player, all_time, weekly, monthly)
+        await interaction.followup.send(embed=embed)
+
+    @app_commands.command(
+        name="weapon", description="Top 10 par arme specifique"
+    )
+    @app_commands.describe(weapon="Type d'arme")
+    @app_commands.choices(
+        weapon=[
+            app_commands.Choice(name="Standard", value="standard"),
+            app_commands.Choice(name="Spread", value="spread"),
+            app_commands.Choice(name="Laser", value="laser"),
+            app_commands.Choice(name="Missile", value="missile"),
+            app_commands.Choice(name="Wave Cannon", value="waveCannon"),
+        ]
+    )
+    async def weapon(self, interaction: discord.Interaction, weapon: str):
+        """Display top players by weapon kills."""
+        await interaction.response.defer()
+
+        data = await LeaderboardRepository.get_top_weapon(weapon, 10)
+
+        weapon_names = {
+            "standard": "Standard",
+            "spread": "Spread",
+            "laser": "Laser",
+            "missile": "Missile",
+            "waveCannon": "Wave Cannon",
+        }
+        weapon_name = weapon_names.get(weapon, weapon)
+
+        embed = discord.Embed(
+            title=f"🔫 TOP 10 - {weapon_name}",
+            color=0xFFD700,
+        )
+
+        if not data:
+            embed.add_field(
+                name="Aucune donnee", value="Pas encore de kills!", inline=False
+            )
+        else:
+            lines = []
+            emojis = ["🥇", "🥈", "🥉"] + [f"{i}." for i in range(4, 11)]
+            field = f"{weapon}Kills"
+
+            for i, entry in enumerate(data):
+                emoji = emojis[i] if i < len(emojis) else f"{i+1}."
+                name = entry.get("playerName", "Unknown")
+                kills = entry.get(field, 0)
+                lines.append(f"{emoji} **{name}** | {kills:,} kills")
+
+            embed.add_field(name="Classement", value="\n".join(lines), inline=False)
+
+        await interaction.followup.send(embed=embed)
+
+
+async def setup(bot: commands.Bot):
+    """Setup function for the cog."""
+    await bot.add_cog(LeaderboardCog(bot))

--- a/discord-bot/leaderboard/cogs/online.py
+++ b/discord-bot/leaderboard/cogs/online.py
@@ -1,0 +1,38 @@
+"""
+Online cog - /online command.
+Shows currently connected players.
+
+NOTE: This requires the R-Type server to persist session data
+to MongoDB collection 'current_game_sessions'.
+"""
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from database.session_repo import SessionRepository
+from utils.embeds import create_online_embed
+
+
+class OnlineCog(commands.Cog):
+    """Online players command."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @app_commands.command(
+        name="online", description="Affiche les joueurs actuellement connectes"
+    )
+    async def online(self, interaction: discord.Interaction):
+        """Display online players."""
+        await interaction.response.defer()
+
+        sessions = await SessionRepository.get_online_players()
+
+        embed = create_online_embed(sessions)
+        await interaction.followup.send(embed=embed)
+
+
+async def setup(bot: commands.Bot):
+    """Setup function for the cog."""
+    await bot.add_cog(OnlineCog(bot))

--- a/discord-bot/leaderboard/cogs/stats.py
+++ b/discord-bot/leaderboard/cogs/stats.py
@@ -1,0 +1,69 @@
+"""
+Stats cog - /stats, /kills commands.
+"""
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from database.player_stats_repo import PlayerStatsRepository
+from utils.embeds import create_stats_embed, create_kills_embed
+
+
+class StatsCog(commands.Cog):
+    """Player stats commands."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    async def player_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for player names."""
+        if len(current) < 1:
+            return []
+        names = await PlayerStatsRepository.search_players(current, limit=25)
+        return [app_commands.Choice(name=n, value=n) for n in names]
+
+    @app_commands.command(name="stats", description="Affiche les stats d'un joueur")
+    @app_commands.describe(player="Nom du joueur")
+    @app_commands.autocomplete(player=player_autocomplete)
+    async def stats(self, interaction: discord.Interaction, player: str):
+        """Display player statistics."""
+        await interaction.response.defer()
+
+        stats = await PlayerStatsRepository.get_by_name(player)
+
+        if not stats:
+            await interaction.followup.send(
+                f"❌ Joueur **{player}** non trouve.", ephemeral=True
+            )
+            return
+
+        embed = create_stats_embed(stats, player)
+        await interaction.followup.send(embed=embed)
+
+    @app_commands.command(
+        name="kills", description="Affiche les kills par arme d'un joueur"
+    )
+    @app_commands.describe(player="Nom du joueur")
+    @app_commands.autocomplete(player=player_autocomplete)
+    async def kills(self, interaction: discord.Interaction, player: str):
+        """Display player kills by weapon."""
+        await interaction.response.defer()
+
+        stats = await PlayerStatsRepository.get_by_name(player)
+
+        if not stats:
+            await interaction.followup.send(
+                f"❌ Joueur **{player}** non trouve.", ephemeral=True
+            )
+            return
+
+        embed = create_kills_embed(stats, player)
+        await interaction.followup.send(embed=embed)
+
+
+async def setup(bot: commands.Bot):
+    """Setup function for the cog."""
+    await bot.add_cog(StatsCog(bot))

--- a/discord-bot/leaderboard/config.py
+++ b/discord-bot/leaderboard/config.py
@@ -1,0 +1,36 @@
+"""
+Configuration module for R-Type Discord Bot.
+Loads environment variables from .env file.
+"""
+
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class Config:
+    """Bot configuration from environment variables."""
+
+    # Discord
+    DISCORD_TOKEN: str = os.getenv("DISCORD_TOKEN", "")
+    DISCORD_GUILD_ID: int | None = (
+        int(os.getenv("DISCORD_GUILD_ID")) if os.getenv("DISCORD_GUILD_ID") else None
+    )
+    STATS_CHANNEL_ID: int | None = (
+        int(os.getenv("STATS_CHANNEL_ID")) if os.getenv("STATS_CHANNEL_ID") else None
+    )
+
+    # MongoDB
+    MONGODB_URI: str = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
+    MONGODB_DB: str = os.getenv("MONGODB_DB", "rtype")
+
+    # Optional
+    LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
+    EMBED_COLOR: int = int(os.getenv("EMBED_COLOR", "0x00FF00"), 16)
+
+    @classmethod
+    def validate(cls) -> None:
+        """Validate required configuration."""
+        if not cls.DISCORD_TOKEN:
+            raise ValueError("DISCORD_TOKEN is required")

--- a/discord-bot/leaderboard/database/__init__.py
+++ b/discord-bot/leaderboard/database/__init__.py
@@ -1,0 +1,13 @@
+"""Database module for R-Type Discord Bot."""
+
+from .mongodb import MongoDB
+from .leaderboard_repo import LeaderboardRepository
+from .player_stats_repo import PlayerStatsRepository
+from .session_repo import SessionRepository
+
+__all__ = [
+    "MongoDB",
+    "LeaderboardRepository",
+    "PlayerStatsRepository",
+    "SessionRepository",
+]

--- a/discord-bot/leaderboard/database/leaderboard_repo.py
+++ b/discord-bot/leaderboard/database/leaderboard_repo.py
@@ -1,0 +1,164 @@
+"""
+Leaderboard repository for MongoDB queries.
+Handles all leaderboard-related database operations.
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from .mongodb import MongoDB
+
+
+class LeaderboardRepository:
+    """Repository for leaderboard queries."""
+
+    @staticmethod
+    def _get_period_filter(period: str) -> dict:
+        """Return timestamp filter for the given period."""
+        now = datetime.utcnow()
+        if period == "weekly":
+            # Start of the week (Monday)
+            start = now - timedelta(days=now.weekday())
+            start = start.replace(hour=0, minute=0, second=0, microsecond=0)
+            return {"timestamp": {"$gte": int(start.timestamp())}}
+        elif period == "monthly":
+            start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            return {"timestamp": {"$gte": int(start.timestamp())}}
+        return {}  # All-time
+
+    @staticmethod
+    async def get_top_scores(period: str = "all", limit: int = 10) -> list[dict]:
+        """Get top N players by best score (grouped by email, one entry per player)."""
+        db = MongoDB.get()
+
+        pipeline = [
+            {"$match": LeaderboardRepository._get_period_filter(period)},
+            {"$sort": {"score": -1}},
+            {
+                "$group": {
+                    "_id": "$email",
+                    "playerName": {"$first": "$playerName"},
+                    "score": {"$max": "$score"},
+                    "wave": {"$first": "$wave"},
+                    "kills": {"$first": "$kills"},
+                    "duration": {"$first": "$duration"},
+                    "timestamp": {"$first": "$timestamp"},
+                }
+            },
+            {"$sort": {"score": -1}},
+            {"$limit": limit},
+        ]
+
+        cursor = db.leaderboard.aggregate(pipeline)
+        return [doc async for doc in cursor]
+
+    @staticmethod
+    async def get_top_kills(limit: int = 10) -> list[dict]:
+        """Get top N players by total kills (from player_stats)."""
+        db = MongoDB.get()
+        cursor = db.player_stats.find().sort("totalKills", -1).limit(limit)
+        return [doc async for doc in cursor]
+
+    @staticmethod
+    async def get_top_waves(limit: int = 10) -> list[dict]:
+        """Get top N players by best wave reached."""
+        db = MongoDB.get()
+        cursor = db.player_stats.find().sort("bestWave", -1).limit(limit)
+        return [doc async for doc in cursor]
+
+    @staticmethod
+    async def get_top_kd(limit: int = 10) -> list[dict]:
+        """Get top N players by K/D ratio."""
+        db = MongoDB.get()
+        pipeline = [
+            {"$match": {"totalDeaths": {"$gt": 0}}},
+            {"$addFields": {"kdRatio": {"$divide": ["$totalKills", "$totalDeaths"]}}},
+            {"$sort": {"kdRatio": -1}},
+            {"$limit": limit},
+        ]
+        cursor = db.player_stats.aggregate(pipeline)
+        return [doc async for doc in cursor]
+
+    @staticmethod
+    async def get_top_bosses(limit: int = 10) -> list[dict]:
+        """Get top N players by boss kills."""
+        db = MongoDB.get()
+        cursor = db.player_stats.find().sort("bossKills", -1).limit(limit)
+        return [doc async for doc in cursor]
+
+    @staticmethod
+    async def get_top_playtime(limit: int = 10) -> list[dict]:
+        """Get top N players by total playtime."""
+        db = MongoDB.get()
+        cursor = db.player_stats.find().sort("totalPlaytime", -1).limit(limit)
+        return [doc async for doc in cursor]
+
+    @staticmethod
+    async def get_top_weapon(weapon: str, limit: int = 10) -> list[dict]:
+        """Get top N players by kills with a specific weapon."""
+        db = MongoDB.get()
+        field = f"{weapon}Kills"  # standardKills, spreadKills, etc.
+        cursor = db.player_stats.find().sort(field, -1).limit(limit)
+        return [doc async for doc in cursor]
+
+    @staticmethod
+    async def get_player_rank(
+        player_name: str, period: str = "all"
+    ) -> Optional[tuple[int, int]]:
+        """
+        Get a player's rank and total player count.
+        Returns (rank, total_players) or None if not found.
+        """
+        db = MongoDB.get()
+
+        # Get the player's best score
+        pipeline = [
+            {
+                "$match": {
+                    "playerName": player_name,
+                    **LeaderboardRepository._get_period_filter(period),
+                }
+            },
+            {"$group": {"_id": "$playerName", "bestScore": {"$max": "$score"}}},
+        ]
+        cursor = db.leaderboard.aggregate(pipeline)
+        player_doc = await cursor.to_list(1)
+
+        if not player_doc:
+            return None
+
+        player_best = player_doc[0]["bestScore"]
+
+        # Count players with higher score
+        count_pipeline = [
+            {"$match": LeaderboardRepository._get_period_filter(period)},
+            {"$group": {"_id": "$email", "bestScore": {"$max": "$score"}}},
+            {"$match": {"bestScore": {"$gt": player_best}}},
+            {"$count": "higher"},
+        ]
+        cursor = db.leaderboard.aggregate(count_pipeline)
+        result = await cursor.to_list(1)
+        higher_count = result[0]["higher"] if result else 0
+
+        # Count total players
+        total_pipeline = [
+            {"$match": LeaderboardRepository._get_period_filter(period)},
+            {"$group": {"_id": "$email"}},
+            {"$count": "total"},
+        ]
+        cursor = db.leaderboard.aggregate(total_pipeline)
+        total_result = await cursor.to_list(1)
+        total_count = total_result[0]["total"] if total_result else 0
+
+        return (higher_count + 1, total_count)
+
+    @staticmethod
+    async def get_all_player_names() -> list[str]:
+        """Get all unique player names for autocomplete."""
+        db = MongoDB.get()
+        cursor = db.player_stats.find({}, {"playerName": 1})
+        names = []
+        async for doc in cursor:
+            if "playerName" in doc:
+                names.append(doc["playerName"])
+        return names

--- a/discord-bot/leaderboard/database/mongodb.py
+++ b/discord-bot/leaderboard/database/mongodb.py
@@ -1,0 +1,52 @@
+"""
+MongoDB client singleton for async operations.
+Uses motor for async MongoDB access.
+"""
+
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
+from typing import Optional
+
+
+class MongoDB:
+    """Singleton MongoDB client."""
+
+    _instance: Optional["MongoDB"] = None
+
+    def __init__(self, client: AsyncIOMotorClient, db_name: str):
+        self.client = client
+        self.db: AsyncIOMotorDatabase = client[db_name]
+
+        # Collections (matching R-Type server)
+        self.leaderboard = self.db["leaderboard"]
+        self.player_stats = self.db["player_stats"]
+        self.game_history = self.db["game_history"]
+        self.achievements = self.db["achievements"]
+        self.users = self.db["user"]
+        self.user_settings = self.db["user_settings"]
+        self.current_sessions = self.db["current_game_sessions"]
+
+    @classmethod
+    async def connect(cls, uri: str, db_name: str) -> "MongoDB":
+        """Connect to MongoDB and return singleton instance."""
+        if cls._instance is None:
+            client = AsyncIOMotorClient(uri)
+            # Test connection
+            await client.admin.command("ping")
+            cls._instance = cls(client, db_name)
+            print(f"MongoDB connected to {db_name}")
+        return cls._instance
+
+    @classmethod
+    def get(cls) -> "MongoDB":
+        """Get the singleton instance. Raises if not connected."""
+        if cls._instance is None:
+            raise RuntimeError("MongoDB not connected. Call connect() first.")
+        return cls._instance
+
+    @classmethod
+    async def close(cls) -> None:
+        """Close the MongoDB connection."""
+        if cls._instance is not None:
+            cls._instance.client.close()
+            cls._instance = None
+            print("MongoDB disconnected")

--- a/discord-bot/leaderboard/database/player_stats_repo.py
+++ b/discord-bot/leaderboard/database/player_stats_repo.py
@@ -1,0 +1,112 @@
+"""
+Player stats repository for MongoDB queries.
+Handles player statistics and achievements.
+"""
+
+from typing import Optional
+
+from .mongodb import MongoDB
+
+
+# Achievement bit positions (matching R-Type server)
+ACHIEVEMENTS = {
+    "First Blood": 0,  # Get 1 kill
+    "Exterminator": 1,  # 1000 total kills
+    "Combo Master": 2,  # Achieve 3.0x combo
+    "Boss Slayer": 3,  # Kill any boss
+    "Survivor": 4,  # Reach wave 20 without dying
+    "Speed Demon": 5,  # Wave 10 in under 5 minutes
+    "Perfectionist": 6,  # Complete wave without damage
+    "Veteran": 7,  # Play 100 games
+    "Untouchable": 8,  # Complete game with 0 deaths
+    "Weapon Master": 9,  # 100+ kills with each weapon
+}
+
+
+class PlayerStatsRepository:
+    """Repository for player statistics queries."""
+
+    @staticmethod
+    async def get_by_name(player_name: str) -> Optional[dict]:
+        """Get player stats by player name."""
+        db = MongoDB.get()
+        return await db.player_stats.find_one({"playerName": player_name})
+
+    @staticmethod
+    async def get_by_email(email: str) -> Optional[dict]:
+        """Get player stats by email."""
+        db = MongoDB.get()
+        return await db.player_stats.find_one({"email": email})
+
+    @staticmethod
+    async def get_game_history(player_name: str, limit: int = 5) -> list[dict]:
+        """Get recent game history for a player."""
+        db = MongoDB.get()
+
+        # First get the email from player_stats
+        stats = await db.player_stats.find_one({"playerName": player_name})
+        if not stats:
+            return []
+
+        email = stats.get("email")
+        if not email:
+            return []
+
+        cursor = (
+            db.game_history.find({"email": email})
+            .sort("timestamp", -1)
+            .limit(limit)
+        )
+        return [doc async for doc in cursor]
+
+    @staticmethod
+    async def get_achievements(player_name: str) -> dict[str, bool]:
+        """Get achievements for a player as a dict of achievement_name -> unlocked."""
+        db = MongoDB.get()
+
+        stats = await db.player_stats.find_one({"playerName": player_name})
+        if not stats:
+            return {name: False for name in ACHIEVEMENTS}
+
+        bitfield = stats.get("achievements", 0)
+
+        return {name: bool(bitfield & (1 << bit)) for name, bit in ACHIEVEMENTS.items()}
+
+    @staticmethod
+    async def get_weapon_stats(player_name: str) -> dict[str, int]:
+        """Get kills per weapon for a player."""
+        db = MongoDB.get()
+
+        stats = await db.player_stats.find_one({"playerName": player_name})
+        if not stats:
+            return {
+                "Standard": 0,
+                "Spread": 0,
+                "Laser": 0,
+                "Missile": 0,
+                "Wave Cannon": 0,
+            }
+
+        return {
+            "Standard": stats.get("standardKills", 0),
+            "Spread": stats.get("spreadKills", 0),
+            "Laser": stats.get("laserKills", 0),
+            "Missile": stats.get("missileKills", 0),
+            "Wave Cannon": stats.get("waveCannonKills", 0),
+        }
+
+    @staticmethod
+    async def search_players(query: str, limit: int = 25) -> list[str]:
+        """Search player names matching query (for autocomplete)."""
+        db = MongoDB.get()
+
+        cursor = db.player_stats.find(
+            {"playerName": {"$regex": f"^{query}", "$options": "i"}},
+            {"playerName": 1},
+        ).limit(limit)
+
+        names = []
+        async for doc in cursor:
+            if "playerName" in doc:
+                names.append(doc["playerName"])
+        return names

--- a/discord-bot/leaderboard/database/session_repo.py
+++ b/discord-bot/leaderboard/database/session_repo.py
@@ -1,0 +1,49 @@
+"""
+Session repository for MongoDB queries.
+Handles online players and active game sessions.
+"""
+
+from .mongodb import MongoDB
+
+
+class SessionRepository:
+    """Repository for active session queries."""
+
+    @staticmethod
+    async def get_online_players() -> list[dict]:
+        """Get all currently online players."""
+        db = MongoDB.get()
+
+        # This collection needs to be populated by the R-Type server
+        # when players join/leave games
+        cursor = db.current_sessions.find()
+        return [doc async for doc in cursor]
+
+    @staticmethod
+    async def get_active_rooms() -> list[dict]:
+        """Get all active rooms with their players."""
+        db = MongoDB.get()
+
+        pipeline = [
+            {
+                "$group": {
+                    "_id": "$roomCode",
+                    "players": {
+                        "$push": {
+                            "playerName": "$playerName",
+                            "wave": "$currentWave",
+                        }
+                    },
+                    "playerCount": {"$sum": 1},
+                }
+            }
+        ]
+
+        cursor = db.current_sessions.aggregate(pipeline)
+        return [doc async for doc in cursor]
+
+    @staticmethod
+    async def get_online_count() -> int:
+        """Get count of online players."""
+        db = MongoDB.get()
+        return await db.current_sessions.count_documents({})

--- a/discord-bot/leaderboard/models/__init__.py
+++ b/discord-bot/leaderboard/models/__init__.py
@@ -1,0 +1,14 @@
+"""Models module for R-Type Discord Bot."""
+
+from .leaderboard_entry import LeaderboardEntry
+from .player_stats import PlayerStats
+from .game_history import GameHistoryEntry
+from .achievement import Achievement, ACHIEVEMENT_DEFINITIONS
+
+__all__ = [
+    "LeaderboardEntry",
+    "PlayerStats",
+    "GameHistoryEntry",
+    "Achievement",
+    "ACHIEVEMENT_DEFINITIONS",
+]

--- a/discord-bot/leaderboard/models/achievement.py
+++ b/discord-bot/leaderboard/models/achievement.py
@@ -1,0 +1,44 @@
+"""Achievement data class and definitions."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Achievement:
+    """Represents an achievement."""
+
+    name: str
+    description: str
+    bit: int
+    unlocked: bool = False
+
+
+# Achievement definitions matching R-Type server
+ACHIEVEMENT_DEFINITIONS = [
+    Achievement("First Blood", "Premier kill", 0),
+    Achievement("Exterminator", "1000 kills total", 1),
+    Achievement("Combo Master", "Combo 3.0x atteint", 2),
+    Achievement("Boss Slayer", "Boss vaincu", 3),
+    Achievement("Survivor", "Wave 20 sans mourir", 4),
+    Achievement("Speed Demon", "Wave 10 en <5min", 5),
+    Achievement("Perfectionist", "Wave sans degats", 6),
+    Achievement("Veteran", "100 parties jouees", 7),
+    Achievement("Untouchable", "Partie sans mourir", 8),
+    Achievement("Weapon Master", "100+ kills chaque arme", 9),
+]
+
+
+def get_achievements_from_bitfield(bitfield: int) -> list[Achievement]:
+    """Convert achievement bitfield to list of Achievement objects."""
+    achievements = []
+    for ach in ACHIEVEMENT_DEFINITIONS:
+        unlocked = bool(bitfield & (1 << ach.bit))
+        achievements.append(
+            Achievement(
+                name=ach.name,
+                description=ach.description,
+                bit=ach.bit,
+                unlocked=unlocked,
+            )
+        )
+    return achievements

--- a/discord-bot/leaderboard/models/game_history.py
+++ b/discord-bot/leaderboard/models/game_history.py
@@ -1,0 +1,27 @@
+"""Game history entry data class."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class GameHistoryEntry:
+    """Represents a single game session in history."""
+
+    score: int
+    wave: int
+    kills: int
+    deaths: int
+    duration: int  # seconds
+    timestamp: int  # unix timestamp
+
+    @classmethod
+    def from_doc(cls, doc: dict) -> "GameHistoryEntry":
+        """Create from MongoDB document."""
+        return cls(
+            score=doc.get("score", 0),
+            wave=doc.get("wave", 0),
+            kills=doc.get("kills", 0),
+            deaths=doc.get("deaths", 0),
+            duration=doc.get("duration", 0),
+            timestamp=doc.get("timestamp", 0),
+        )

--- a/discord-bot/leaderboard/models/leaderboard_entry.py
+++ b/discord-bot/leaderboard/models/leaderboard_entry.py
@@ -1,0 +1,32 @@
+"""Leaderboard entry data class."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class LeaderboardEntry:
+    """Represents a leaderboard entry."""
+
+    rank: int
+    player_name: str
+    score: int
+    wave: int
+    kills: int
+    duration: int  # seconds
+    timestamp: int  # unix timestamp
+    email: Optional[str] = None
+
+    @classmethod
+    def from_doc(cls, doc: dict, rank: int) -> "LeaderboardEntry":
+        """Create from MongoDB document."""
+        return cls(
+            rank=rank,
+            player_name=doc.get("playerName", "Unknown"),
+            score=doc.get("score", 0),
+            wave=doc.get("wave", 0),
+            kills=doc.get("kills", 0),
+            duration=doc.get("duration", 0),
+            timestamp=doc.get("timestamp", 0),
+            email=doc.get("_id") or doc.get("email"),
+        )

--- a/discord-bot/leaderboard/models/player_stats.py
+++ b/discord-bot/leaderboard/models/player_stats.py
@@ -1,0 +1,86 @@
+"""Player stats data class."""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class PlayerStats:
+    """Represents player statistics."""
+
+    player_name: str
+    email: str
+
+    # General stats
+    games_played: int = 0
+    total_kills: int = 0
+    total_deaths: int = 0
+    total_score: int = 0
+    best_score: int = 0
+    best_wave: int = 0
+    best_combo: int = 10  # x10 format (30 = 3.0x)
+    boss_kills: int = 0
+    total_playtime: int = 0  # seconds
+
+    # Weapon kills
+    standard_kills: int = 0
+    spread_kills: int = 0
+    laser_kills: int = 0
+    missile_kills: int = 0
+    wave_cannon_kills: int = 0
+
+    # Achievement bitfield
+    achievements: int = 0
+
+    @property
+    def kd_ratio(self) -> float:
+        """Calculate K/D ratio."""
+        if self.total_deaths == 0:
+            return float(self.total_kills)
+        return self.total_kills / self.total_deaths
+
+    @property
+    def combo_display(self) -> str:
+        """Format combo for display (30 -> 3.0x)."""
+        return f"{self.best_combo / 10:.1f}x"
+
+    @property
+    def weapon_kills(self) -> dict[str, int]:
+        """Get kills per weapon as dict."""
+        return {
+            "Standard": self.standard_kills,
+            "Spread": self.spread_kills,
+            "Laser": self.laser_kills,
+            "Missile": self.missile_kills,
+            "Wave Cannon": self.wave_cannon_kills,
+        }
+
+    @property
+    def favorite_weapon(self) -> tuple[str, int]:
+        """Get favorite weapon (name, kills)."""
+        weapons = self.weapon_kills
+        name = max(weapons, key=weapons.get)
+        return (name, weapons[name])
+
+    @classmethod
+    def from_doc(cls, doc: dict) -> "PlayerStats":
+        """Create from MongoDB document."""
+        return cls(
+            player_name=doc.get("playerName", "Unknown"),
+            email=doc.get("email", ""),
+            games_played=doc.get("gamesPlayed", 0),
+            total_kills=doc.get("totalKills", 0),
+            total_deaths=doc.get("totalDeaths", 0),
+            total_score=doc.get("totalScore", 0),
+            best_score=doc.get("bestScore", 0),
+            best_wave=doc.get("bestWave", 0),
+            best_combo=doc.get("bestCombo", 10),
+            boss_kills=doc.get("bossKills", 0),
+            total_playtime=doc.get("totalPlaytime", 0),
+            standard_kills=doc.get("standardKills", 0),
+            spread_kills=doc.get("spreadKills", 0),
+            laser_kills=doc.get("laserKills", 0),
+            missile_kills=doc.get("missileKills", 0),
+            wave_cannon_kills=doc.get("waveCannonKills", 0),
+            achievements=doc.get("achievements", 0),
+        )

--- a/discord-bot/leaderboard/requirements.txt
+++ b/discord-bot/leaderboard/requirements.txt
@@ -1,0 +1,7 @@
+# Discord Bot - Leaderboard Module
+# R-Type Project
+
+discord.py>=2.3.0
+motor>=3.3.0
+python-dotenv>=1.0.0
+pymongo>=4.6.0

--- a/discord-bot/leaderboard/utils/__init__.py
+++ b/discord-bot/leaderboard/utils/__init__.py
@@ -1,0 +1,25 @@
+"""Utils module for R-Type Discord Bot."""
+
+from .formatters import format_number, format_duration, format_timestamp
+from .embeds import (
+    create_leaderboard_embed,
+    create_stats_embed,
+    create_kills_embed,
+    create_online_embed,
+    create_achievements_embed,
+    create_history_embed,
+    create_rank_embed,
+)
+
+__all__ = [
+    "format_number",
+    "format_duration",
+    "format_timestamp",
+    "create_leaderboard_embed",
+    "create_stats_embed",
+    "create_kills_embed",
+    "create_online_embed",
+    "create_achievements_embed",
+    "create_history_embed",
+    "create_rank_embed",
+]

--- a/discord-bot/leaderboard/utils/embeds.py
+++ b/discord-bot/leaderboard/utils/embeds.py
@@ -1,0 +1,277 @@
+"""Discord embed generators for R-Type Bot."""
+
+import discord
+from typing import Optional
+
+from .formatters import (
+    format_number,
+    format_duration,
+    format_timestamp,
+    format_game_duration,
+    progress_bar,
+)
+from models.leaderboard_entry import LeaderboardEntry
+from models.player_stats import PlayerStats
+from models.game_history import GameHistoryEntry
+from models.achievement import Achievement
+
+# Rank emojis
+RANK_EMOJIS = ["🥇", "🥈", "🥉"] + [f"{i}." for i in range(4, 11)]
+
+# Weapon emojis
+WEAPON_EMOJIS = {
+    "Standard": "🔵",
+    "Spread": "🟢",
+    "Laser": "🔴",
+    "Missile": "🟡",
+    "Wave Cannon": "🟣",
+}
+
+# Colors
+GOLD = 0xFFD700
+GREEN = 0x00FF00
+RED = 0xFF4444
+BLUE = 0x4444FF
+
+
+def create_leaderboard_embed(
+    entries: list[dict],
+    category: str,
+    period: str,
+) -> discord.Embed:
+    """Create leaderboard embed."""
+    period_names = {"all": "All-Time", "weekly": "Weekly", "monthly": "Monthly"}
+    category_names = {
+        "score": "Score",
+        "kills": "Kills",
+        "wave": "Wave",
+        "kd": "K/D Ratio",
+        "bosses": "Boss Kills",
+        "playtime": "Temps de jeu",
+    }
+
+    embed = discord.Embed(
+        title=f"🏆 LEADERBOARD - TOP 10 ({period_names.get(period, period)})",
+        description=f"Classement par **{category_names.get(category, category)}**",
+        color=GOLD,
+    )
+
+    if not entries:
+        embed.add_field(
+            name="Aucune donnee", value="Personne n'a encore joue!", inline=False
+        )
+        return embed
+
+    lines = []
+    for i, entry in enumerate(entries):
+        emoji = RANK_EMOJIS[i] if i < len(RANK_EMOJIS) else f"{i+1}."
+        name = entry.get("playerName", "Unknown")
+
+        if category == "score":
+            value = f"{format_number(entry.get('score', 0))} pts"
+        elif category == "kills":
+            value = f"{format_number(entry.get('totalKills', 0))} kills"
+        elif category == "wave":
+            value = f"Wave {entry.get('bestWave', 0)}"
+        elif category == "kd":
+            kd = entry.get("kdRatio", 0)
+            value = f"{kd:.2f} K/D"
+        elif category == "bosses":
+            value = f"{entry.get('bossKills', 0)} boss"
+        elif category == "playtime":
+            value = format_duration(entry.get("totalPlaytime", 0))
+        else:
+            value = "N/A"
+
+        lines.append(f"{emoji} **{name}** | {value}")
+
+    embed.add_field(name="Classement", value="\n".join(lines), inline=False)
+    embed.set_footer(text="R-Type Leaderboard")
+
+    return embed
+
+
+def create_stats_embed(stats: dict, player_name: str) -> discord.Embed:
+    """Create player stats embed."""
+    embed = discord.Embed(title=f"📊 STATS - {player_name}", color=GREEN)
+
+    # General stats
+    kd = stats.get("totalKills", 0) / max(stats.get("totalDeaths", 1), 1)
+    general = (
+        f"🎯 **Score Total** | {format_number(stats.get('totalScore', 0))}\n"
+        f"🏆 **Meilleur Score** | {format_number(stats.get('bestScore', 0))}\n"
+        f"⚔️ **Total Kills** | {format_number(stats.get('totalKills', 0))}\n"
+        f"💀 **Total Deaths** | {format_number(stats.get('totalDeaths', 0))}\n"
+        f"📈 **K/D Ratio** | {kd:.2f}"
+    )
+    embed.add_field(name="General", value=general, inline=True)
+
+    # Records
+    combo = stats.get("bestCombo", 10) / 10
+    records = (
+        f"🌊 **Meilleure Wave** | {stats.get('bestWave', 0)}\n"
+        f"🔥 **Meilleur Combo** | {combo:.1f}x\n"
+        f"⏱️ **Temps de jeu** | {format_duration(stats.get('totalPlaytime', 0))}\n"
+        f"🎮 **Parties jouees** | {stats.get('gamesPlayed', 0)}\n"
+        f"👹 **Boss tues** | {stats.get('bossKills', 0)}"
+    )
+    embed.add_field(name="Records", value=records, inline=True)
+
+    # Favorite weapon
+    weapons = {
+        "Standard": stats.get("standardKills", 0),
+        "Spread": stats.get("spreadKills", 0),
+        "Laser": stats.get("laserKills", 0),
+        "Missile": stats.get("missileKills", 0),
+        "Wave Cannon": stats.get("waveCannonKills", 0),
+    }
+    favorite = max(weapons, key=weapons.get)
+    emoji = WEAPON_EMOJIS.get(favorite, "🔫")
+
+    embed.add_field(
+        name="🔫 Arme favorite",
+        value=f"{emoji} **{favorite}** ({format_number(weapons[favorite])} kills)",
+        inline=False,
+    )
+
+    return embed
+
+
+def create_kills_embed(stats: dict, player_name: str) -> discord.Embed:
+    """Create kills breakdown embed."""
+    embed = discord.Embed(title=f"⚔️ KILLS - {player_name}", color=RED)
+
+    weapons = {
+        "Standard": stats.get("standardKills", 0),
+        "Spread": stats.get("spreadKills", 0),
+        "Laser": stats.get("laserKills", 0),
+        "Missile": stats.get("missileKills", 0),
+        "Wave Cannon": stats.get("waveCannonKills", 0),
+    }
+
+    total = sum(weapons.values())
+    embed.description = f"**Total: {format_number(total)} kills**\n"
+
+    lines = []
+    for name, kills in weapons.items():
+        pct = (kills / total * 100) if total > 0 else 0
+        bar = progress_bar(kills, total)
+        emoji = WEAPON_EMOJIS.get(name, "🔹")
+        lines.append(f"{emoji} **{name}** | {bar} | {format_number(kills)} ({pct:.0f}%)")
+
+    embed.add_field(name="Detail par arme", value="\n".join(lines), inline=False)
+
+    return embed
+
+
+def create_online_embed(sessions: list[dict]) -> discord.Embed:
+    """Create online players embed."""
+    embed = discord.Embed(
+        title=f"🟢 JOUEURS EN LIGNE ({len(sessions)})",
+        color=GREEN,
+    )
+
+    if not sessions:
+        embed.description = "Aucun joueur connecte"
+        return embed
+
+    # Group by room
+    rooms: dict[str, list[dict]] = {}
+    for session in sessions:
+        room = session.get("roomCode", "Unknown")
+        if room not in rooms:
+            rooms[room] = []
+        rooms[room].append(session)
+
+    lines = []
+    for room, players in rooms.items():
+        player_names = ", ".join([p.get("playerName", "???") for p in players])
+        wave = players[0].get("currentWave", "?") if players else "?"
+        lines.append(f"🎮 **Room {room}** | Wave {wave} | {player_names}")
+
+    embed.add_field(name="Sessions actives", value="\n".join(lines), inline=False)
+    embed.set_footer(text=f"Rooms actives: {len(rooms)}")
+
+    return embed
+
+
+def create_achievements_embed(
+    achievements: dict[str, bool], player_name: str
+) -> discord.Embed:
+    """Create achievements embed."""
+    unlocked = sum(1 for v in achievements.values() if v)
+    total = len(achievements)
+
+    embed = discord.Embed(
+        title=f"🏅 ACHIEVEMENTS - {player_name} ({unlocked}/{total})",
+        color=GOLD if unlocked == total else GREEN,
+    )
+
+    # Achievement descriptions
+    descriptions = {
+        "First Blood": "Premier kill",
+        "Exterminator": "1000 kills total",
+        "Combo Master": "Combo 3.0x atteint",
+        "Boss Slayer": "Boss vaincu",
+        "Survivor": "Wave 20 sans mourir",
+        "Speed Demon": "Wave 10 en <5min",
+        "Perfectionist": "Wave sans degats",
+        "Veteran": "100 parties jouees",
+        "Untouchable": "Partie sans mourir",
+        "Weapon Master": "100+ kills chaque arme",
+    }
+
+    lines = []
+    for name, unlocked in achievements.items():
+        status = "✅" if unlocked else "❌"
+        desc = descriptions.get(name, "")
+        lines.append(f"{status} **{name}** | {desc}")
+
+    embed.add_field(name="Liste", value="\n".join(lines), inline=False)
+
+    return embed
+
+
+def create_history_embed(history: list[dict], player_name: str) -> discord.Embed:
+    """Create game history embed."""
+    embed = discord.Embed(title=f"📜 HISTORIQUE - {player_name}", color=BLUE)
+
+    if not history:
+        embed.description = "Aucune partie enregistree"
+        return embed
+
+    lines = []
+    for i, game in enumerate(history, 1):
+        when = format_timestamp(game.get("timestamp", 0))
+        score = format_number(game.get("score", 0))
+        wave = game.get("wave", 0)
+        kills = game.get("kills", 0)
+        duration = format_game_duration(game.get("duration", 0))
+
+        lines.append(f"{i}. {when} | {score} pts | Wave {wave} | {kills} kills | ⏱️ {duration}")
+
+    embed.add_field(name="Dernieres parties", value="\n".join(lines), inline=False)
+
+    return embed
+
+
+def create_rank_embed(
+    player_name: str,
+    all_time: Optional[tuple[int, int]],
+    weekly: Optional[tuple[int, int]],
+    monthly: Optional[tuple[int, int]],
+) -> discord.Embed:
+    """Create rank embed."""
+    embed = discord.Embed(title=f"📍 RANK - {player_name}", color=GREEN)
+
+    def format_rank(data: Optional[tuple[int, int]]) -> str:
+        if data is None:
+            return "N/A"
+        rank, total = data
+        return f"#{rank} / {total} joueurs"
+
+    embed.add_field(name="🌍 All-Time", value=format_rank(all_time), inline=True)
+    embed.add_field(name="📅 Weekly", value=format_rank(weekly), inline=True)
+    embed.add_field(name="📆 Monthly", value=format_rank(monthly), inline=True)
+
+    return embed

--- a/discord-bot/leaderboard/utils/formatters.py
+++ b/discord-bot/leaderboard/utils/formatters.py
@@ -1,0 +1,57 @@
+"""Formatting utilities for R-Type Discord Bot."""
+
+from datetime import datetime
+
+
+def format_number(n: int) -> str:
+    """Format number with space separators (1234567 -> 1 234 567)."""
+    return f"{n:,}".replace(",", " ")
+
+
+def format_duration(seconds: int) -> str:
+    """Format duration in hours/minutes (3661 -> 1h 1m)."""
+    if seconds < 60:
+        return f"{seconds}s"
+    elif seconds < 3600:
+        mins = seconds // 60
+        secs = seconds % 60
+        return f"{mins}m {secs}s" if secs > 0 else f"{mins}m"
+    else:
+        hours = seconds // 3600
+        minutes = (seconds % 3600) // 60
+        return f"{hours}h {minutes}m"
+
+
+def format_timestamp(ts: int) -> str:
+    """Format timestamp as relative time (Il y a 2h, Hier, etc.)."""
+    now = datetime.utcnow()
+    dt = datetime.utcfromtimestamp(ts)
+    diff = now - dt
+
+    if diff.days == 0:
+        if diff.seconds < 60:
+            return "A l'instant"
+        elif diff.seconds < 3600:
+            return f"Il y a {diff.seconds // 60}m"
+        return f"Il y a {diff.seconds // 3600}h"
+    elif diff.days == 1:
+        return "Hier"
+    elif diff.days < 7:
+        return f"Il y a {diff.days}j"
+    else:
+        return dt.strftime("%d/%m/%Y")
+
+
+def format_game_duration(seconds: int) -> str:
+    """Format game duration as MM:SS."""
+    mins = seconds // 60
+    secs = seconds % 60
+    return f"{mins:02d}:{secs:02d}"
+
+
+def progress_bar(value: int, max_value: int, length: int = 16) -> str:
+    """Create a text progress bar."""
+    if max_value == 0:
+        return "░" * length
+    filled = int((value / max_value) * length)
+    return "█" * filled + "░" * (length - filled)


### PR DESCRIPTION
## Summary

Ajout du bot Discord pour afficher les statistiques R-Type.

### Commandes disponibles
- `/leaderboard [category] [period]` - Top 10 joueurs (score, kills, wave, K/D, boss, playtime)
- `/stats <player>` - Statistiques detaillees d'un joueur
- `/kills <player>` - Repartition des kills par arme
- `/achievements <player>` - Liste des 10 succes
- `/history <player>` - Historique des dernieres parties
- `/rank <player>` - Classement all-time, weekly, monthly
- `/weapon <type>` - Top 10 par arme specifique

### Architecture
```
discord-bot/leaderboard/
├── bot.py                 # Point d'entree
├── config.py              # Configuration (.env)
├── requirements.txt       # Dependencies Python
├── cogs/                  # Modules de commandes
├── database/              # Repositories MongoDB (motor async)
├── models/                # Dataclasses
└── utils/                 # Embeds et formatters
```

### Stack
- Python 3.11+
- discord.py 2.x
- motor (MongoDB async)

### Deploiement
Bot deja deploye et actif sur le VPS en tant que service systemd (`rtype-discord-bot.service`).

## Test plan
- [x] Bot connecte a MongoDB
- [x] Service systemd actif et enabled
- [x] Commandes slash enregistrees sur Discord
- [ ] Tester avec donnees reelles apres merge du leaderboard