### PR TITLE
feat(discord): Autocomplétion des joueurs pour le bot Leaderboard

### DIFF
--- a/discord-bot/leaderboard/cogs/achievements.py
+++ b/discord-bot/leaderboard/cogs/achievements.py
@@ -20,8 +20,6 @@ class AchievementsCog(commands.Cog):
         self, interaction: discord.Interaction, current: str
     ) -> list[app_commands.Choice[str]]:
         """Autocomplete for player names."""
-        if len(current) < 1:
-            return []
         names = await PlayerStatsRepository.search_players(current, limit=25)
         return [app_commands.Choice(name=n, value=n) for n in names]
 

--- a/discord-bot/leaderboard/cogs/history.py
+++ b/discord-bot/leaderboard/cogs/history.py
@@ -21,8 +21,6 @@ class HistoryCog(commands.Cog):
         self, interaction: discord.Interaction, current: str
     ) -> list[app_commands.Choice[str]]:
         """Autocomplete for player names."""
-        if len(current) < 1:
-            return []
         names = await PlayerStatsRepository.search_players(current, limit=25)
         return [app_commands.Choice(name=n, value=n) for n in names]
 

--- a/discord-bot/leaderboard/cogs/leaderboard.py
+++ b/discord-bot/leaderboard/cogs/leaderboard.py
@@ -21,8 +21,6 @@ class LeaderboardCog(commands.Cog):
         self, interaction: discord.Interaction, current: str
     ) -> list[app_commands.Choice[str]]:
         """Autocomplete for player names."""
-        if len(current) < 1:
-            return []
         names = await PlayerStatsRepository.search_players(current, limit=25)
         return [app_commands.Choice(name=n, value=n) for n in names]
 

--- a/discord-bot/leaderboard/cogs/stats.py
+++ b/discord-bot/leaderboard/cogs/stats.py
@@ -20,8 +20,6 @@ class StatsCog(commands.Cog):
         self, interaction: discord.Interaction, current: str
     ) -> list[app_commands.Choice[str]]:
         """Autocomplete for player names."""
-        if len(current) < 1:
-            return []
         names = await PlayerStatsRepository.search_players(current, limit=25)
         return [app_commands.Choice(name=n, value=n) for n in names]
 


### PR DESCRIPTION
## Summary
- Autocomplétion des joueurs pour toutes les commandes du bot Leaderboard
- Recherche dans les collections player_stats ET user de MongoDB
- Affichage immédiat des joueurs sans taper de caractère

## Commandes concernées
- `/stats` - Statistiques d'un joueur
- `/kills` - Kills par arme
- `/achievements` - Succès d'un joueur
- `/history` - Historique des parties
- `/rank` - Classement d'un joueur

## Test plan
- [x] Vérifier que l'autocomplétion affiche les joueurs sans taper
- [x] Vérifier que la recherche filtre correctement en tapant
- [x] Tester avec des joueurs qui n'ont pas encore joué (collection user uniquement)